### PR TITLE
Remove debugging code that prints to STDOUT

### DIFF
--- a/lib/dream-see-do-api.rb
+++ b/lib/dream-see-do-api.rb
@@ -1,7 +1,5 @@
 require 'json_api_client'
 
-puts defined?(JsonApiClient::Paginating::Paginator.page_param)
-
 if defined?(JsonApiClient::Paginating::Paginator.page_param)
   # Use correct page parameters for Network API
   # (only works when included in Rails environment)


### PR DESCRIPTION
It prints "method" whenever the gem is required.